### PR TITLE
Remove superfluous -X POST args implied by -F

### DIFF
--- a/k8s/cron.yaml
+++ b/k8s/cron.yaml
@@ -13,8 +13,6 @@ spec:
           - name: curl
             image: curlimages/curl
             args:
-            - -X
-            - POST
             - -F
             - token=$(TOKEN)
             - -F


### PR DESCRIPTION
Re: https://github.com/mozilla/release-notes/commit/7f053a431c37c724ae5c0d291e8b4e73153748af#r36466993