### PR TITLE
Remove unnecessary leading whitespace in bug_search_url

### DIFF
--- a/releases/firefox-for-ios-1.2-release.json
+++ b/releases/firefox-for-ios-1.2-release.json
@@ -1,6 +1,6 @@
 {
   "bug_list": "",
-  "bug_search_url": " https://bugzilla.mozilla.org/buglist.cgi?f1=cf_tracking_fxios&list_id=12692445&o1=substring&resolution=---&resolution=FIXED&resolution=INVALID&resolution=WONTFIX&resolution=DUPLICATE&resolution=WORKSFORME&resolution=INCOMPLETE&resolution=SUPPORT&resolution=EXPIRED&resolution=MOVED&query_based_on=v1.2&query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED&v1=1.2&product=Firefox%20for%20iOS&known_name=v1.2",
+  "bug_search_url": "https://bugzilla.mozilla.org/buglist.cgi?f1=cf_tracking_fxios&list_id=12692445&o1=substring&resolution=---&resolution=FIXED&resolution=INVALID&resolution=WONTFIX&resolution=DUPLICATE&resolution=WORKSFORME&resolution=INCOMPLETE&resolution=SUPPORT&resolution=EXPIRED&resolution=MOVED&query_based_on=v1.2&query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED&v1=1.2&product=Firefox%20for%20iOS&known_name=v1.2",
   "channel": "Release",
   "created": "2015-11-19T14:34:37+00:00",
   "is_public": true,


### PR DESCRIPTION
Not sure if this also needs to be fixed upstream in Nucleus, so also edited it there https://nucleus.mozilla.org/admin/rna/release/370/

This change is needed to satisfy an outbound-link checker run against www.mozilla.org