### PR TITLE
feature(mirroring): Use github actions for mirroring

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -1,0 +1,17 @@
+name: Mirror repo
+on: [push]
+
+jobs:
+  mirror:
+    if: github.repository == 'mozilla/release-notes'
+    runs-on: ubuntu-latest
+    steps:
+       - name: mirror in gitlab
+         uses: actions/checkout@v3
+         with:
+          fetch-depth: 0
+       - uses: yesolutions/mirror-action@71cd8f5b5c9c4a461f477ecccace98850cb04bc1
+         with:
+            REMOTE: 'https://gitlab.com/mozmeao/release-notes.git'
+            GIT_USERNAME: ${{ secrets.GITLAB_USERNAME }}
+            GIT_PASSWORD: ${{ secrets.GITLAB_PASSWORD }}


### PR DESCRIPTION
# One-line summary

Re-enable our GitLab mirroring using GitHub actions. I will need help setting the secrets here before merging.

Should I add a CODEOWNERS file as well that has some restrictions around .github?

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/SE-3234
