### PR TITLE
Clarify that "edit existing text annotations" is about PDFs

### DIFF
--- a/releases/firefox-116.0-release.json
+++ b/releases/firefox-116.0-release.json
@@ -52,7 +52,7 @@
       "id": 789597,
       "is_public": true,
       "modified": "2023-08-03T15:00:34.032382+00:00",
-      "note": "We added the possibility to edit existing text annotations.",
+      "note": "We added the possibility to edit existing text annotations in the PDF reader.",
       "sort_num": 0,
       "tag": "New"
     },


### PR DESCRIPTION
I wasn't sure what "We added the possibility to edit existing text annotations" meant until I looked at the linked bug:

https://bugzilla.mozilla.org/show_bug.cgi?id=1838799
